### PR TITLE
Compatibility with Quest Framework

### DIFF
--- a/BillboardProfitMargin/src/ModEntry.cs
+++ b/BillboardProfitMargin/src/ModEntry.cs
@@ -56,7 +56,7 @@
 			Quest dailyQuest = Game1.questOfTheDay;
 			if (dailyQuest == null) return;
 
-			if (dailyQuest is ItemDeliveryQuest itemDeliveryQuest)
+			if (dailyQuest is ItemDeliveryQuest itemDeliveryQuest && dailyQuest.id.Value == 0)
 			{
 					itemDeliveryQuest.loadQuestInfo();
 					this.UpdateItemDeliveryQuest(itemDeliveryQuest);


### PR DESCRIPTION
Hi,

Your mod BillboardProfitMargin has bad compatibility with QF. Your mod destroys quest information for managed quests under QF which are offered on billboard in town. I added check, which do your margin edits only on vanilla quests (by check quest id is zero, QF offered quests has id >0).

How it is in conflict you can see here: https://github.com/purrplingcat/QuestFramework/blob/709524222b42c047edbd9a7d1a2db04219c4db34/src/Framework/Controllers/QuestController.cs#L177

PurrplingCat

PS: Untested, I did this change by the eye look here in GH.